### PR TITLE
Analyze and improve code performance and robustness

### DIFF
--- a/ANALYSIS.md
+++ b/ANALYSIS.md
@@ -1,0 +1,60 @@
+# Code Analysis for Family Photo Booth
+
+## Overview
+The `index.html` file contains a complete Single Page Application (SPA) for a web-based photo booth. It utilizes the device's camera via `getUserMedia` and applies real-time visual effects using WebGL.
+
+### Key Features
+- **Camera Access:** Captures video stream from the user's camera.
+- **WebGL Rendering:** Renders the video stream on a canvas using WebGL.
+- **Effects:** Implements 20 different visual effects using GLSL fragment shaders (e.g., Bulge, Pinch, Twirl, Kaleido).
+- **Snapshot:** Allows users to take a snapshot, which downloads the current frame as a PNG image.
+- **Countdown:** Visual countdown before taking a snapshot.
+- **UI:** Responsive design using Tailwind CSS.
+
+## Code Structure
+- **HTML:** Defines the layout, including the video element (hidden), canvas, buttons, and effect selection list.
+- **CSS:** Tailwind CSS is used for styling. Custom CSS handles animations and specific effect card styles.
+- **JavaScript:**
+  - `startCamera()`: Initializes the camera stream.
+  - `render()`: Main render loop, called via `requestAnimationFrame`. Handles WebGL drawing.
+  - `initShaders()`: Compiles and links shader programs for all defined effects.
+  - `createShader()`: Helper to compile a shader.
+  - `buildList()`: Generates the UI for effect selection.
+  - Event listeners for buttons.
+
+## Identified Issues & Areas for Improvement
+
+### 1. Performance
+- **Repeated Attribute Lookups:**
+  The `render` function calls `gl.getAttribLocation` and `gl.getUniformLocation` in every frame for the active program.
+  ```javascript
+  const pos = gl.getAttribLocation(p, "aPosition");
+  const tc = gl.getAttribLocation(p, "aTexCoord");
+  // ...
+  gl.uniform1f(gl.getUniformLocation(p, "uTime"), time * 0.001);
+  gl.uniform2f(gl.getUniformLocation(p, "uResolution"), canvas.width, canvas.height);
+  ```
+  **Impact:** `getAttribLocation` and `getUniformLocation` are relatively expensive operations involving string lookups. Doing this 60 times per second for every frame is inefficient.
+  **Recommendation:** Cache these locations during the initialization phase (`initShaders`) and store them with the program object.
+
+### 2. Robustness & Error Handling
+- **Shader Compilation:**
+  The `createShader` function checks for compilation status but returns `null` on failure without detailed error logging.
+  If it returns `null`, `gl.attachShader` in `initShaders` will likely throw an error or fail silently depending on browser implementation, potentially crashing the initialization.
+- **Program Linking:**
+  `gl.linkProgram` is called, but its success status is not checked. If linking fails, the program will be invalid, and `gl.useProgram` in the render loop will fail.
+- **Missing Effect Fallback:**
+  If a specific effect's shader fails to compile/link, the `programs` object might have an invalid entry. The render loop tries to use `programs[activeEffect]`, but if that program is invalid/null, it might crash or cause WebGL errors.
+
+### 3. Best Practices
+- **Attribute Enabling:**
+  `gl.enableVertexAttribArray` is called every frame. While less critical than location lookup, it's better state management to handle this efficiently (though WebGL state machine makes this tricky if switching programs often, but here we only switch when user selects a new effect).
+- **Resource Cleanup:**
+  There is no mechanism to delete shaders or programs if they are no longer needed, though in this simple app they persist for the lifetime of the page.
+
+## Proposed Fixes
+1.  **Cache Locations:** Modify `initShaders` to return an object containing the program and its attribute/uniform locations.
+2.  **Add Error Checking:** Enhance `createShader` and `initShaders` to log errors to the console if compilation or linking fails.
+3.  **Graceful Failure:** If an effect fails to load, mark it as invalid or fallback to the 'normal' effect to prevent application crashes.
+
+I will implement these fixes in the next step.

--- a/index.html
+++ b/index.html
@@ -270,7 +270,11 @@
             const s = gl.createShader(type);
             gl.shaderSource(s, source);
             gl.compileShader(s);
-            if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) return null;
+            if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+                console.error('Shader compile error:', gl.getShaderInfoLog(s));
+                gl.deleteShader(s);
+                return null;
+            }
             return s;
         }
 
@@ -279,10 +283,29 @@
                 const vs = createShader(gl, gl.VERTEX_SHADER, vsSource);
                 const fsSource = fsHeader + (eff.fs || `void main() { gl_FragColor = texture2D(uSampler, vTexCoord); }`);
                 const fs = createShader(gl, gl.FRAGMENT_SHADER, fsSource);
+
+                if (!vs || !fs) {
+                    console.error(`Failed to compile shader for effect: ${eff.id}`);
+                    return;
+                }
+
                 const p = gl.createProgram();
                 gl.attachShader(p, vs); gl.attachShader(p, fs);
                 gl.linkProgram(p);
-                programs[eff.id] = p;
+
+                if (!gl.getProgramParameter(p, gl.LINK_STATUS)) {
+                    console.error(`Failed to link program for effect: ${eff.id}`, gl.getProgramInfoLog(p));
+                    gl.deleteProgram(p);
+                    return;
+                }
+
+                programs[eff.id] = {
+                    program: p,
+                    aPosition: gl.getAttribLocation(p, "aPosition"),
+                    aTexCoord: gl.getAttribLocation(p, "aTexCoord"),
+                    uTime: gl.getUniformLocation(p, "uTime"),
+                    uResolution: gl.getUniformLocation(p, "uResolution")
+                };
             });
         }
 
@@ -318,18 +341,25 @@
         function render(time) {
             if (video.readyState < 2) return requestAnimationFrame(render);
             gl.viewport(0, 0, canvas.width, canvas.height);
-            const p = programs[activeEffect] || programs.normal;
-            gl.useProgram(p);
 
-            const pos = gl.getAttribLocation(p, "aPosition");
-            const tc = gl.getAttribLocation(p, "aTexCoord");
-            gl.enableVertexAttribArray(pos); gl.vertexAttribPointer(pos, 2, gl.FLOAT, false, 16, 0);
-            gl.enableVertexAttribArray(tc); gl.vertexAttribPointer(tc, 2, gl.FLOAT, false, 16, 8);
+            let progData = programs[activeEffect];
+            if (!progData) progData = programs['normal'];
+            if (!progData) return requestAnimationFrame(render);
+
+            const { program, aPosition, aTexCoord, uTime, uResolution } = progData;
+            gl.useProgram(program);
+
+            gl.enableVertexAttribArray(aPosition);
+            gl.vertexAttribPointer(aPosition, 2, gl.FLOAT, false, 16, 0);
+
+            gl.enableVertexAttribArray(aTexCoord);
+            gl.vertexAttribPointer(aTexCoord, 2, gl.FLOAT, false, 16, 8);
 
             gl.bindTexture(gl.TEXTURE_2D, tex);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, video);
-            gl.uniform1f(gl.getUniformLocation(p, "uTime"), time * 0.001);
-            gl.uniform2f(gl.getUniformLocation(p, "uResolution"), canvas.width, canvas.height);
+
+            if (uTime) gl.uniform1f(uTime, time * 0.001);
+            if (uResolution) gl.uniform2f(uResolution, canvas.width, canvas.height);
 
             gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
             requestAnimationFrame(render);


### PR DESCRIPTION
Analyzed the `index.html` file and identified performance inefficiencies (repeated `getAttribLocation` calls) and robustness issues (lack of shader error handling).

Created `ANALYSIS.md` to document findings.

Refactored `index.html` to:
1.  Cache attribute and uniform locations in `initShaders` instead of querying them every frame in `render`.
2.  Add console error logging when shader compilation or linking fails.
3.  Gracefully handle failed shader programs by falling back to the 'normal' effect or skipping the invalid program, preventing application crashes.

Verified changes using a Playwright script with a fake media stream.

---
*PR created automatically by Jules for task [7328477996023088556](https://jules.google.com/task/7328477996023088556) started by @a33707*

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 3 no changes — [View all](https://hub.continue.dev/inbox/pr/a33707/my-photobooth/1?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->